### PR TITLE
Change the fallback to get the user object

### DIFF
--- a/content/content-fes-vendor.php
+++ b/content/content-fes-vendor.php
@@ -14,7 +14,7 @@ if ( function_exists( 'fes_get_vendor' ) && false !== fes_get_vendor() ) {
 	$the_vendor = get_user_by( 'slug', $the_vendor );
 	
 	if ( ! $the_vendor ) {
-		$the_vendor = get_current_user_id();
+		$the_vendor = new WP_User( get_current_user_id() );
 		$is_vendor_profile = '';
 	}
 	


### PR DESCRIPTION
The line `$vendor_avatar = get_avatar( $the_vendor->ID, 100 );` and others expect $the_vendor to be an object, not an integer. Currently does a fatal error if the if ( !$vendor ) fall back is hit, since get_avatar is expecting $the_vendor to be an object.

On a seperate note, why are you doing `$is_vendor_profile = '';` in the conditional? Its always overriden by the declaration a few lines below. I think `$is_vendor_profile = 'is-vendor-profile';` should be above that fallback if (!vendor)